### PR TITLE
ポケモン課題を提出

### DIFF
--- a/ruby/pokemon/name_service.rb
+++ b/ruby/pokemon/name_service.rb
@@ -1,0 +1,11 @@
+module NameService
+  def change_name(new_name)
+    raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+  end
+
+  def get_name
+    raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+  end
+
+end
+

--- a/ruby/pokemon/pikachu.rb
+++ b/ruby/pokemon/pikachu.rb
@@ -1,0 +1,10 @@
+class Pikachu < Pokemon
+
+  def initialize(type1, type2, hp)
+    super
+  end
+
+  def attack
+    puts "#{name}の10万ボルト"
+  end
+end

--- a/ruby/pokemon/pokemon.rb
+++ b/ruby/pokemon/pokemon.rb
@@ -1,0 +1,26 @@
+class Pokemon
+  include NameService
+
+  private attr_accessor :name
+
+  def initialize(type1, type2, hp)
+    @name = ''
+    @type1 = type1
+    @type2 = type2
+    @hp = hp
+  end
+
+  def get_name
+    self.name
+  end
+
+  def change_name(new_name)
+    return '不適切' if new_name == 'XXX'
+    @name=(new_name)
+  end
+
+  def attack
+    raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+  end
+
+end


### PR DESCRIPTION
## 課題のリンク

https://github.com/happiness-chain/practice/blob/main/08_ruby/004_ruby%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3.md

## やったこと
ポケモン課題の実装。

## 質問
抽象化するにあたり、未実装の場合のエラーとして抽象メソッドを以下のような記述方法で実装しました。
```ruby
def attack
  raise NotImplementedError, "You must implement #{self.class}##{__method__}"
end
```
しかし、実際の実装で全ての実装にこの記述をするのは冗長だと考え、定数に例外時のメッセージを格納した場合、クラスとメソッドが参照できておらず、うまくいきませんでした。(変数に格納されているが、呼び出す際はメソッド内で呼び出すため、この方法で可能ではと考えたたため、試してみました。)
```
NOT_IMPLEMNET_ERROR = "You must implement #{self.class}##{__method__}"

#パターン1
def attack
   raise NotImplementedError, NOT_IMPLEMNET_ERROR
end

#パターン2
def attack
   raise NotImplementedError, "#{NOT_IMPLEMNET_ERROR}"
end

#実行結果
(irb):14:in `get_name': You must implement Module# (NotImplementedError)
```

どのように実装するのが正しいでしょうか。
